### PR TITLE
Fix error being logged for every request

### DIFF
--- a/webdav.go
+++ b/webdav.go
@@ -76,10 +76,12 @@ func (wd WebDAV) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 		FileSystem: webdav.Dir(root),
 		LockSystem: wd.lockSystem,
 		Logger: func(req *http.Request, err error) {
-			wd.logger.Error("internal handler error",
-				zap.Error(err),
-				zap.Object("request", caddyhttp.LoggableHTTPRequest{Request: req}),
-			)
+			if err != nil {
+				wd.logger.Error("internal handler error",
+					zap.Error(err),
+					zap.Object("request", caddyhttp.LoggableHTTPRequest{Request: req}),
+				)
+			}
 		},
 	}
 


### PR DESCRIPTION
According to [golang.org/x/net/webdav.Handler](https://pkg.go.dev/golang.org/x/net/webdav?tab=doc#Handler), the logger is called for every request, regardless of if `err` is `nil` or not.

This fixes error messages being logged for every WebDAV request.